### PR TITLE
Typo with Initializer Lists

### DIFF
--- a/07-Considering_Performance.md
+++ b/07-Considering_Performance.md
@@ -96,8 +96,8 @@ auto mos = std::vector<ModelObject>{mo1, mo2};
 ```c++
 // Don't do this
 std::vector<ModelObject> mos;
-mo.push_back(mo1);
-mo.push_back(mo2);
+mos.push_back(mo1);
+mos.push_back(mo2);
 ```
 
 Initializer lists are significantly more efficient; reducing object copies and resizing of containers


### PR DESCRIPTION
```mo``` should be ```mos```