### PR TITLE
Suggestion: Adding M&M rule to Threadability

### DIFF
--- a/07-Considering_Threadability.md
+++ b/07-Considering_Threadability.md
@@ -8,4 +8,11 @@ Global data leads to unintended side effects between functions and can make code
 
 ## Avoid Heap Operations
 
-Much slower in threaded environments. In many or maybe even most cases, copying data is faster. Plus with move operations and such and things
+Much slower in threaded environments. In many or maybe even most cases, copying data is faster. Plus with move operations and such and things.
+
+## Mutex and mutable go together (M&M rule, C++11)
+
+For member variables it is good practice to use mutex and mutable together. This applies in both ways:
+1) A mutable member variable is presumed to be a shared variable so it should be synchronized with a mutex (or made atomic)
+2) If a member variable is itself a mutex, it should be mutable. This is required to use it inside a const member function.
+

--- a/07-Considering_Threadability.md
+++ b/07-Considering_Threadability.md
@@ -11,8 +11,6 @@ Global data leads to unintended side effects between functions and can make code
 Much slower in threaded environments. In many or maybe even most cases, copying data is faster. Plus with move operations and such and things.
 
 ## Mutex and mutable go together (M&M rule, C++11)
-
 For member variables it is good practice to use mutex and mutable together. This applies in both ways:
-1) A mutable member variable is presumed to be a shared variable so it should be synchronized with a mutex (or made atomic)
-2) If a member variable is itself a mutex, it should be mutable. This is required to use it inside a const member function.
-
+* A mutable member variable is presumed to be a shared variable so it should be synchronized with a mutex (or made atomic)
+* If a member variable is itself a mutex, it should be mutable. This is required to use it inside a const member function.

--- a/07-Considering_Threadability.md
+++ b/07-Considering_Threadability.md
@@ -14,3 +14,5 @@ Much slower in threaded environments. In many or maybe even most cases, copying 
 For member variables it is good practice to use mutex and mutable together. This applies in both ways:
 * A mutable member variable is presumed to be a shared variable so it should be synchronized with a mutex (or made atomic)
 * If a member variable is itself a mutex, it should be mutable. This is required to use it inside a const member function.
+
+For more information see the following article from Herb Sutter: http://herbsutter.com/2013/05/24/gotw-6a-const-correctness-part-1-3/


### PR DESCRIPTION
I would suggest to add the M&M rule (c++11) to Threadability:
Mutex and mutable go together

For more information to this rule see the blog from Herb Sutter:
http://herbsutter.com/2013/05/24/gotw-6a-const-correctness-part-1-3/