### PR TITLE
Continuous Integration: If you mention Hudson you should mention Jenkins too

### DIFF
--- a/02-Use_the_Tools_Available.md
+++ b/02-Use_the_Tools_Available.md
@@ -38,7 +38,10 @@ Continuous Integration (CI) tools automatically build the source code as changes
  * [AppVeyor](http://www.appveyor.com/)
    * supports Windows, MSVC and MinGW
    * free for public repositoris on GitHub
- * [Hudson CI](http://hudson-ci.org/)
+ * [Hudson CI](http://hudson-ci.org/) / [Jenkins CI](https://jenkins-ci.org/)
+   * Java Application Server is required
+   * supports Windows, OS X, and Linux
+   * extendable with a lot of plugins
  * [TeamCity](https://www.jetbrains.com/teamcity) 
    * has a free option for open source projects
  * [Decent CI](https://github.com/lefticus/decent_ci)


### PR DESCRIPTION
Jenkins is a fork of Hudson that was released in 2011. At the moment Jenkins seems to be significantly more used than Hudson.