### PR TITLE
Updated a link to new site

### DIFF
--- a/03-Style.md
+++ b/03-Style.md
@@ -384,5 +384,5 @@ The Rule of Zero states that you do not provide any of the functions that the co
 
 The goal is to let the compiler provide optimal versions that are automatically maintained when more member variables are added.
 
-The [original article](http://flamingdangerzone.com/cxx11/rule-of-zero/) provides the background, while a [follow up article](https://turingtester.wordpress.com/2015/06/27/cs-rule-of-zero/) explains techniques for implementing nearly 100% of the time.
+The [original article](http://flamingdangerzone.com/cxx11/rule-of-zero/) provides the background, while a [follow up article](http://www.nirfriedman.com/2015/06/27/cpp-rule-of-zero/) explains techniques for implementing nearly 100% of the time.
 


### PR DESCRIPTION
The content has moved to a new site and the currently linked version has code formatting issues.