### PR TITLE
Updated URL for Google Test

### DIFF
--- a/02-Use_the_Tools_Available.md
+++ b/02-Use_the_Tools_Available.md
@@ -227,7 +227,7 @@ If it is determined by team consensus that the compiler or analyzer is warning o
 
 CMake, mentioned above, has a built in framework for executing tests. Make sure whatever build system you use has a way to execute tests built in.
 
-To further aid in executing tests, consider a library such as [Google Test](https://code.google.com/p/googletest/), [Catch](https://github.com/philsquared/Catch) or [Boost.Test](http://www.boost.org/doc/libs/release/libs/test/) to help you organize the tests.
+To further aid in executing tests, consider a library such as [Google Test](https://github.com/google/googletest), [Catch](https://github.com/philsquared/Catch) or [Boost.Test](http://www.boost.org/doc/libs/release/libs/test/) to help you organize the tests.
 
 ### Unit Tests
 


### PR DESCRIPTION
Google Test was moved from code.google.com to github.