### PR TITLE
static constant floating point use constexpr

### DIFF
--- a/05-Considering_Maintainability.md
+++ b/05-Considering_Maintainability.md
@@ -16,7 +16,7 @@ namespace my_project {
     // if the above macro would be expanded, then the following line would be:
     //   static const double 3.14159 = 3.14159;
     // which leads to a compile-time error. Sometimes such errors are hard to understand.
-    static const double PI = 3.14159;
+    static constexpr double PI = 3.14159;
   };
 }
 ```


### PR DESCRIPTION
Prior to C++11, only static const data members of
integral or enumeration type could have initializers
in the class definition. C++11 extends that to
floating point types (float, double) as well.
However, in order for such members to be initialized
in the class defintion, such members must either be
constexpr or non-static.