### PR TITLE
/W14640 => /w14640

### DIFF
--- a/02-Use_the_Tools_Available.md
+++ b/02-Use_the_Tools_Available.md
@@ -127,7 +127,7 @@ Consider using `-Weverything` and disabling the few warnings you need to on Clan
 
 `/permissive-` - [Enforces standards conformance](https://docs.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance).
 
-`/W4 /W14640` - use these and consider the following (see descriptions below)
+`/W4 /w14640` - use these and consider the following (see descriptions below)
 
  * `/W4` All reasonable warnings
  * `/w14242` 'identfier': conversion from 'type1' to 'type1', possible loss of data


### PR DESCRIPTION
In the "MSVC" section, "/w14640" is correctly given as lowercase in the detailed list, but wrongly given with uppercase "W" in the summary above.