### PR TITLE
add GCC/Clang compiler versions for warning flags

### DIFF
--- a/02-Use_the_Tools_Available.md
+++ b/02-Use_the_Tools_Available.md
@@ -105,18 +105,18 @@ You should use as many compilers as you can for your platform(s). Each compiler 
  * `-Wcast-align` warn for potential performance problem casts
  * `-Wunused` warn on anything being unused
  * `-Woverloaded-virtual` warn if you overload (not override) a virtual function
- * `-Wpedantic` warn if non-standard C++ is used
+ * `-Wpedantic` (GCC only) warn if non-standard C++ is used
  * `-Wconversion` warn on type conversions that may lose data
- * `-Wsign-conversion` warn on sign conversions
- * `-Wmisleading-indentation` warn if indentation implies blocks where blocks do not exist
- * `-Wduplicated-cond` warn if `if` / `else` chain has duplicated conditions
- * `-Wduplicated-branches` warn if `if` / `else` branches have duplicated code
- * `-Wlogical-op` warn about logical operations being used where bitwise were probably wanted
- * `-Wnull-dereference` warn if a null dereference is detected
- * `-Wuseless-cast` warn if you perform a cast to the same type
- * `-Wdouble-promotion` warn if `float` is implicit promoted to `double`
+ * `-Wsign-conversion` (Clang all versions, GCC >= 4.3) warn on sign conversions
+ * `-Wmisleading-indentation` (only in GCC >= 6.0) warn if indentation implies blocks where blocks do not exist
+ * `-Wduplicated-cond` (only in GCC >= 6.0) warn if `if` / `else` chain has duplicated conditions
+ * `-Wduplicated-branches` (only in GCC >= 7.0) warn if `if` / `else` branches have duplicated code
+ * `-Wlogical-op` (only in GCC) warn about logical operations being used where bitwise were probably wanted
+ * `-Wnull-dereference` (only in GCC >= 6.0) warn if a null dereference is detected
+ * `-Wuseless-cast` (only in GCC >= 4.8) warn if you perform a cast to the same type
+ * `-Wdouble-promotion` (GCC >= 4.6, Clang >= 3.8) warn if `float` is implicit promoted to `double`
  * `-Wformat=2` warn on security issues around functions that format output (ie `printf`)
- * `-Wlifetime` (clang only currently) shows object lifetime issues
+ * `-Wlifetime` (only special branch of Clang currently) shows object lifetime issues
  
 Consider using `-Weverything` and disabling the few warnings you need to on Clang
 

--- a/02-Use_the_Tools_Available.md
+++ b/02-Use_the_Tools_Available.md
@@ -105,7 +105,7 @@ You should use as many compilers as you can for your platform(s). Each compiler 
  * `-Wcast-align` warn for potential performance problem casts
  * `-Wunused` warn on anything being unused
  * `-Woverloaded-virtual` warn if you overload (not override) a virtual function
- * `-Wpedantic` (GCC only) warn if non-standard C++ is used
+ * `-Wpedantic` (all versions of GCC, Clang >= 3.2) warn if non-standard C++ is used
  * `-Wconversion` warn on type conversions that may lose data
  * `-Wsign-conversion` (Clang all versions, GCC >= 4.3) warn on sign conversions
  * `-Wmisleading-indentation` (only in GCC >= 6.0) warn if indentation implies blocks where blocks do not exist


### PR DESCRIPTION
Added a note like (only in GCC >= 4.8) or (GCC >= 4.6, Clang >= 3.8) for every suggested -Wxxx flag since they are not uniformly supported. Based on WARN_FLAGS setup code in https://github.com/ashutosh108/sb-sloka-counter/blob/d209af97b567e4e92ed8ca7500e34c759a860885/CMakeLists.txt. Verified by using godbolt.org and digging around release notes.