### PR TITLE
/Wx raises Command-Line Error D8021

### DIFF
--- a/02-Use_the_Tools_Available.md
+++ b/02-Use_the_Tools_Available.md
@@ -164,7 +164,7 @@ Not recommended
 
 Start with very strict warning settings from the beginning. Trying to raise the warning level after the project is underway can be painful.
 
-Consider using the *treat warnings as errors* setting. `/Wx` with MSVC, `-Werror` with GCC / Clang
+Consider using the *treat warnings as errors* setting. `/WX` with MSVC, `-Werror` with GCC / Clang
 
 ## LLVM-based tools
 


### PR DESCRIPTION
The correct arg has a capital X `/WX`. `/Wx` is treated like `/W<number>` but fails the parsing and generates an invalid number (I suppose).