### PR TITLE
Denote `override` and `final` as code

### DIFF
--- a/05-Considering_Maintainability.md
+++ b/05-Considering_Maintainability.md
@@ -53,6 +53,6 @@ The `assert()` will be removed in release builds which will prevent the `set_val
 So while the second version is uglier, the first version is simply not correct.
 
 
-## Properly Utilize 'override' and 'final'
+## Properly Utilize `override` and `final`
 
 These keywords make it clear to other developers how virtual functions are being utilized, can catch potential errors if the signature of a virtual function changes, and can possibly [hint to the compiler](http://stackoverflow.com/questions/7538820/how-does-the-compiler-benefit-from-cs-new-final-keyword) of optimizations that can be performed.


### PR DESCRIPTION
Since `override` and `final` are [keywords](https://en.cppreference.com/w/cpp/keyword), they deserve to be _highlighted_ as code, similarly as `double` and `float` in [here](https://github.com/cpp-best-practices/cppbestpractices/blob/master/08-Considering_Performance.md#prefer-double-to-float-but-test-first) or `assert` in [here](https://github.com/cpp-best-practices/cppbestpractices/blob/master/05-Considering_Maintainability.md#never-use-assert-with-side-effects).

Yes, this PR is just a typo fix.