### PR TITLE
Fix CMake/C++ Starter Project Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 Collaborative Collection of C++ Best Practices
 
-For more information please see the [Preface](01-Preface.md).
+For more information, please see the [Preface](01-Preface.md).
 
 This online resource is part of Jason Turner's collection of C++ Best Practices resources.
 
 * [C++ Best Practices Book](https://leanpub.com/cppbestpractices)
 * [C++ Weekly YouTube Channel](https://www.youtube.com/user/lefticus1)
-* [The Ultimate CMake/C++ Starter Project](https://github.com/lefticus/cpp_starter_project/)
+* [The Ultimate CMake/C++ Starter Project](https://github.com/cpp-best-practices/cmake_template)
 * [Learning C++ Best Practices - O'Reilly Video](http://shop.oreilly.com/product/0636920049814.do)


### PR DESCRIPTION
This change fixes the project link in the README. Before, it was linking to the archived project under @lefticus, which appears to be stale and/or moved to `cpp-best-practices` Github org.